### PR TITLE
fix: LSP DetectionMethod should not ignore `exclude_dirs`

### DIFF
--- a/lua/project_nvim/project.lua
+++ b/lua/project_nvim/project.lua
@@ -14,8 +14,8 @@ M.last_project = nil
 ---@param buffer_id integer
 ---@return boolean
 local function is_lsp_with_root_dir(lsp_client, buffer_id)
-  return lsp_client.config.root_dir ~= nil
-    and lsp_client.attached_buffers[buffer_id]
+  return lsp_client.attached_buffers[buffer_id]
+    and lsp_client.config.root_dir ~= nil
     and not path.is_excluded(lsp_client.config.root_dir)
     and not vim.tbl_contains(config.options.ignore_lsp, lsp_client.name)
 end

--- a/lua/project_nvim/project.lua
+++ b/lua/project_nvim/project.lua
@@ -16,6 +16,7 @@ M.last_project = nil
 local function is_lsp_with_root_dir(lsp_client, buffer_id)
   return lsp_client.config.root_dir ~= nil
     and lsp_client.attached_buffers[buffer_id]
+    and not path.is_excluded(lsp_client.config.root_dir)
     and not vim.tbl_contains(config.options.ignore_lsp, lsp_client.name)
 end
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of language server clients by ensuring those with excluded root directories are no longer considered valid, resulting in more accurate project detection and management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->