### PR TITLE
fix: Pattern DetectionMethod should not ignore `exclude_dirs`

### DIFF
--- a/lua/project_nvim/project.lua
+++ b/lua/project_nvim/project.lua
@@ -33,6 +33,7 @@ end
 function M.find_pattern_root()
   local search_dir = vim.fn.expand("%:p:h", true)
   if vim.fn.has("win32") > 0 then search_dir = search_dir:gsub("\\", "/") end
+  if path.is_excluded(search_dir) then return nil end
 
   local last_dir_cache = ""
   local curr_dir_cache = {}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved project root detection by ensuring excluded directories are skipped immediately, preventing unnecessary processing when the starting directory is excluded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->