### PR TITLE
refactor!: add "v1." suffix to old types

### DIFF
--- a/lua/project-v1/config.lua
+++ b/lua/project-v1/config.lua
@@ -1,6 +1,6 @@
 local M = {}
 
----@class ProjectOptions
+---@class v1.ProjectOptions
 M.defaults = {
   manual_mode = false,
   detection_methods = { "lsp", "pattern" },
@@ -13,7 +13,7 @@ M.defaults = {
   datapath = vim.fn.stdpath("data"),
 }
 
----@type ProjectOptions
+---@type v1.ProjectOptions
 M.options = {}
 
 M.setup = function(options)

--- a/lua/project-v1/types.lua
+++ b/lua/project-v1/types.lua
@@ -1,4 +1,4 @@
----@class ProjectOptions
+---@class v1.ProjectOptions
 ---
 --- Manual mode doesn't automatically change your root directory, so you have the option to manually do so using
 --- `:ProjectRoot` command.
@@ -6,7 +6,7 @@
 ---
 --- Methods of detecting the root directory. Here order matters: if one is not detected, the other is used as fallback.
 --- You can also delete or rearrange the detection methods.
----@field detection_methods? DetectionMethod[]
+---@field detection_methods? v1.DetectionMethod[]
 ---
 --- All the patterns used to detect root dir, when `"pattern"` is in `detection_methods`.
 ---@field patterns? string[]
@@ -26,16 +26,16 @@
 ---@field silent_chdir? boolean
 ---
 --- What scope to change the directory.
----@field scope_chdir? ChdirScope
+---@field scope_chdir? v1.ChdirScope
 ---
 --- Path where project.nvim will store the project history for use in telescope.
 ---@field datapath? string
 
----@alias DetectionMethod
+---@alias v1.DetectionMethod
 ---| "lsp" uses the native neovim lsp
 ---| "pattern" uses vim-rooter like glob pattern matching.
 
----@alias ChdirScope
+---@alias v1.ChdirScope
 ---| "global" (default)
 ---| "tab"
 ---| "win"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated type annotations to use namespaced versions for improved clarity in documentation. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->